### PR TITLE
add LLVM pass

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/devcontainers/cpp:0-debian-11
+
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Optionally install the cmake for vcpkg
+COPY ./reinstall-cmake.sh /tmp/
+
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+    chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# [Optional] Uncomment this section to install additional vcpkg ports.
+# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
+
+# [Optional] Uncomment this section to install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends lsb-release wget software-properties-common gnupg
+
+# Install LLVM
+RUN bash -c "cd /tmp && wget https://apt.llvm.org/llvm.sh && chmod +x ./llvm.sh && ./llvm.sh 14"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/reinstall-cmake.sh
+++ b/.devcontainer/reinstall-cmake.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+set -e
+
+CMAKE_VERSION=${1:-"none"}
+
+if [ "${CMAKE_VERSION}" = "none" ]; then
+    echo "No CMake version specified, skipping CMake reinstallation"
+    exit 0
+fi
+
+# Cleanup temporary directory and associated files when exiting the script.
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    if [[ -n "${TMP_DIR}" ]]; then
+        echo "Executing cleanup of tmp files"
+        rm -Rf "${TMP_DIR}"
+    fi
+    exit $EXIT_CODE
+}
+trap cleanup EXIT
+
+
+echo "Installing CMake..."
+apt-get -y purge --auto-remove cmake
+mkdir -p /opt/cmake
+
+architecture=$(dpkg --print-architecture)
+case "${architecture}" in
+    arm64)
+        ARCH=aarch64 ;;
+    amd64)
+        ARCH=x86_64 ;;
+    *)
+        echo "Unsupported architecture ${architecture}."
+        exit 1
+        ;;
+esac
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
+TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
+
+echo "${TMP_DIR}"
+cd "${TMP_DIR}"
+
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
+
+sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
+sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
+
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+build/*
+!build/.keep
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "C_Cpp.default.includePath": [
+    "/usr/include/llvm-14",
+    "/usr/include/llvm-c-14"
+  ],
+  "C_Cpp.clang_format_fallbackStyle": "Google",
+  "cmake.configureOnOpen": false
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(Tivo)
+
+# support C++14 features used by LLVM 10.0.0
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(LLVM REQUIRED CONFIG)
+add_definitions(${LLVM_DEFINITIONS})
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+
+add_subdirectory(tivo-pass)  # Use your pass name here.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # tivo
 research project exploring record and replay at the LLVM level
+
+## Build Tivo LLVM Pass
+
+```sh
+cd build
+cmake ..
+make # generates `./build/tivo-pass/libTivoPass.so`
+
+# compile with the pass
+clang-14 -O0 -flegacy-pass-manager -Xclang -load -Xclang ./build/tivo-pass/libTivoPass.so ./foo.c
+```

--- a/test-programs/src/cas.c
+++ b/test-programs/src/cas.c
@@ -1,0 +1,16 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+bool __tivo_sync_bool_compare_and_swap_4(volatile int32_t* data,
+                                         volatile int32_t expected,
+                                         volatile int32_t desired) {
+  bool result = __sync_bool_compare_and_swap_4(data, expected, desired);
+  printf("TODO: do record or replay\n");
+  return result;
+}
+
+int main(int argc, char** argv) {
+  int32_t data, expected, desired;
+  int a = __sync_bool_compare_and_swap_4(&data, expected, desired);
+}

--- a/tivo-pass/CMakeLists.txt
+++ b/tivo-pass/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(TivoPass MODULE
+  TivoPass.cpp
+)
+
+# Use C++11 to compile our pass (i.e., supply -std=c++11).
+target_compile_features(TivoPass PRIVATE cxx_range_for cxx_auto_type)
+
+# LLVM is (typically) built with no C++ RTTI. We need to match that;
+# otherwise, we'll get linker errors about missing RTTI data.
+set_target_properties(TivoPass PROPERTIES
+  COMPILE_FLAGS "-fno-rtti"
+)
+
+# Get proper shared-library behavior (where symbols are not necessarily
+# resolved when the shared library is linked) on OS X.
+if(APPLE)
+  set_target_properties(TivoPass PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup"
+  )
+endif(APPLE)

--- a/tivo-pass/TivoPass.cpp
+++ b/tivo-pass/TivoPass.cpp
@@ -18,7 +18,7 @@ struct TivoPass : public FunctionPass {
   TivoPass() : FunctionPass(ID) {}
 
   virtual bool runOnFunction(Function &F) {
-    // if the function begins with the `__i_` prefix, skip
+    // if the function begins with the `__tivo_` prefix, skip
     if (F.getName().str().rfind("__tivo_", 0) == 0) {
       return false;
     }
@@ -37,23 +37,11 @@ struct TivoPass : public FunctionPass {
           // replace I with a function call
           errs() << "Replacing with a function call: " << I << "\n";
           IRBuilder<> builder(op);
-          // builder.SetInsertPoint(&B, ++builder.GetInsertPoint());
 
           Value *args[] = {op->getOperand(0), op->getOperand(1),
                            op->getOperand(2)};
 
           builder.CreateCall(logCASFunc, args);
-        }
-        if (auto *op = dyn_cast<BinaryOperator>(&I)) {
-          // Insert *after* `op`.
-          IRBuilder<> builder(op);
-          builder.SetInsertPoint(&B, ++builder.GetInsertPoint());
-
-          // Insert a call to our function.
-          Value *args[] = {op->getOperand(0), op->getOperand(1), op};
-          builder.CreateCall(logAddFunc, args);
-
-          return true;
         }
       }
     }

--- a/tivo-pass/TivoPass.cpp
+++ b/tivo-pass/TivoPass.cpp
@@ -1,0 +1,74 @@
+#include <string>
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+using namespace std;
+using namespace llvm;
+
+namespace {
+struct TivoPass : public FunctionPass {
+  static char ID;
+  TivoPass() : FunctionPass(ID) {}
+
+  virtual bool runOnFunction(Function &F) {
+    // if the function begins with the `__i_` prefix, skip
+    if (F.getName().str().rfind("__tivo_", 0) == 0) {
+      return false;
+    }
+
+    LLVMContext &Ctx = F.getContext();
+    FunctionCallee logAddFunc = F.getParent()->getOrInsertFunction(
+        "logop", Type::getVoidTy(Ctx), Type::getInt32Ty(Ctx));
+
+    FunctionCallee logCASFunc = F.getParent()->getOrInsertFunction(
+        "__tivo_sync_bool_compare_and_swap_4", Type::getVoidTy(Ctx),
+        Type::getInt32PtrTy(Ctx), Type::getInt32Ty(Ctx), Type::getInt32Ty(Ctx));
+
+    for (auto &B : F) {
+      for (auto &I : B) {
+        if (auto *op = dyn_cast<AtomicCmpXchgInst>(&I)) {
+          // replace I with a function call
+          errs() << "Replacing with a function call: " << I << "\n";
+          IRBuilder<> builder(op);
+          // builder.SetInsertPoint(&B, ++builder.GetInsertPoint());
+
+          Value *args[] = {op->getOperand(0), op->getOperand(1),
+                           op->getOperand(2)};
+
+          builder.CreateCall(logCASFunc, args);
+        }
+        if (auto *op = dyn_cast<BinaryOperator>(&I)) {
+          // Insert *after* `op`.
+          IRBuilder<> builder(op);
+          builder.SetInsertPoint(&B, ++builder.GetInsertPoint());
+
+          // Insert a call to our function.
+          Value *args[] = {op->getOperand(0), op->getOperand(1), op};
+          builder.CreateCall(logAddFunc, args);
+
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+};
+}  // namespace
+
+char TivoPass::ID = 0;
+
+// Automatically enable the pass.
+// http://adriansampson.net/blog/clangpass.html
+static void registerTivoPass(const PassManagerBuilder &,
+                             legacy::PassManagerBase &PM) {
+  PM.add(new TivoPass());
+}
+static RegisterStandardPasses RegisterMyPass(
+    PassManagerBuilder::EP_EarlyAsPossible, registerTivoPass);


### PR DESCRIPTION
This PR adds files related to our LLVM pass.

- The `tivo-pass` directory contains the source for the LLVM Pass
- Added a section to README.me that describes how to compile the pass and use it
- `.devcontainer` contains the definition of the container I'm using. I can remove it but it may be useful to have a consistent environment.